### PR TITLE
Fix url variable name to account

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This is because the plugin also provides a configuration closure called `snowfla
 ```groovy
 snowflake {
     // All the following options are provided in my local gradle.properties file
-    // url = <snowflake account url>
+    // account = <snowflake account url>
     // user = <snowflake user>
     // password = <snowflake password>
     role = 'stewart_role'
@@ -124,7 +124,7 @@ Instead, they are in my local `gradle.properties` file, and any of the plugin co
 
 ```properties
 # local file in ~/.gradle/gradle.properties
-snowflake.url = https://myorg.snowflakecomputing.com:443
+snowflake.account = https://myorg.snowflakecomputing.com:443
 snowflake.user = myusername
 snowflake.password = mypassword
 ```
@@ -185,7 +185,7 @@ Looking at the [sample project](examples/external-stage/), notice we've populate
 ```groovy
 snowflake {
     // All the following options are provided in my local gradle.properties file
-    // url = <snowflake account url>
+    // account = <snowflake account url>
     // user = <snowflake user>
     // password = <snowflake password>
     // publishUrl = <S3 bucket and path>

--- a/examples/external-stage/build.gradle
+++ b/examples/external-stage/build.gradle
@@ -16,7 +16,7 @@ java {
 
 snowflake {
     // All the following options are provided in my local gradle.properties file
-    // url = <snowflake account url>
+    // account = <snowflake account url>
     // user = <snowflake user>
     // password = <snowflake password>
     // publishUrl = <S3 bucket and path>

--- a/examples/groovy-jar/build.gradle
+++ b/examples/groovy-jar/build.gradle
@@ -20,7 +20,7 @@ java {
 
 snowflake {
     // All the following options are provided in my local gradle.properties file
-    // url = <snowflake account url>
+    // account = <snowflake account url>
     // user = <snowflake user>
     // password = <snowflake password>
     role = 'stewart_role'

--- a/examples/internal-stage/build.gradle
+++ b/examples/internal-stage/build.gradle
@@ -16,7 +16,7 @@ java {
 
 snowflake {
     // All the following options are provided in my local gradle.properties file
-    // url = <snowflake account url>
+    // account = <snowflake account url>
     // user = <snowflake user>
     // password = <snowflake password>
     role = 'stewart_role'

--- a/examples/kotlin-jar/build.gradle
+++ b/examples/kotlin-jar/build.gradle
@@ -16,7 +16,7 @@ java {
 
 snowflake {
     // All the following options are provided in my local gradle.properties file
-    // url = <snowflake account url>
+    // account = <snowflake account url>
     // user = <snowflake user>
     // password = <snowflake password>
     role = 'stewart_role'

--- a/examples/scala-jar/build.gradle
+++ b/examples/scala-jar/build.gradle
@@ -20,7 +20,7 @@ java {
 
 snowflake {
     // All the following options are provided in my local gradle.properties file
-    // url = <snowflake account url>
+    // account = <snowflake account url>
     // user = <snowflake user>
     // password = <snowflake password>
     role = 'stewart_role'


### PR DESCRIPTION
The variable name `url` in the `build.gradle` files of the examples are not accepted by the `SnowflakeExtension` class. The relevant variable name which is accepted is `account`. Prior to any changes, the attached exception log is thrown. This PR changes relevant `url` variables to be named `account`

```
A problem occurred evaluating root project 'internal-stage'.
> Could not set unknown property 'url' for extension 'snowflake' of type io.github.stewartbryson.SnowflakeExtension.

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating root project 'internal-stage'.
	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:93)
	at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.lambda$apply$0(DefaultScriptPluginFactory.java:133)
	at org.gradle.configuration.ProjectScriptTarget.addConfiguration(ProjectScriptTarget.java:79)
	at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:136)
…
Caused by: groovy.lang.MissingPropertyException: Could not set unknown property 'url' for extension 'snowflake' of type io.github.stewartbryson.SnowflakeExtension.
	at org.gradle.internal.metaobject.AbstractDynamicObject.setMissingProperty(AbstractDynamicObject.java:118)
	at org.gradle.internal.metaobject.ConfigureDelegate.setProperty(ConfigureDelegate.java:111)
	at build_3vjug5ao5qij93cd1d9r4ysss$_run_closure3.doCall(/Users/jcui/gradle-snowflake/examples/internal-stage/build.gradle:19)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.gradle.util.internal.ClosureBackedAction.execute(ClosureBackedAction.java:73)
	at org.gradle.util.internal.ConfigureUtil.configureTarget(ConfigureUtil.java:155)
	at org.gradle.util.internal.ConfigureUtil.configure(ConfigureUtil.java:106)
	at org.gradle.util.internal.ConfigureUtil$WrappedConfigureAction.execute(ConfigureUtil.java:167)
	at org.gradle.internal.extensibility.ExtensionsStorage$ExtensionHolder.configure(ExtensionsStorage.java:173)
	at org.gradle.internal.extensibility.ExtensionsStorage.configureExtension(ExtensionsStorage.java:64)
	at org.gradle.internal.extensibility.DefaultConvention.configureExtension(DefaultConvention.java:364)
	at org.gradle.internal.extensibility.DefaultConvention.access$500(DefaultConvention.java:45)
	at org.gradle.internal.extensibility.DefaultConvention$ExtensionsDynamicObject.tryInvokeMethod(DefaultConvention.java:301)
	at org.gradle.internal.metaobject.CompositeDynamicObject.tryInvokeMethod(CompositeDynamicObject.java:98)
	at org.gradle.internal.extensibility.MixInClosurePropertiesAsMethodsDynamicObject.tryInvokeMethod(MixInClosurePropertiesAsMethodsDynamicObject.java:36)
	at org.gradle.groovy.scripts.BasicScript$ScriptDynamicObject.tryInvokeMethod(BasicScript.java:135)
	at org.gradle.internal.metaobject.AbstractDynamicObject.invokeMethod(AbstractDynamicObject.java:163)
	at org.gradle.groovy.scripts.BasicScript.invokeMethod(BasicScript.java:84)
	at build_3vjug5ao5qij93cd1d9r4ysss.run(/Users/jcui/gradle-snowflake/examples/internal-stage/build.gradle:17)
	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:91)
	... 161 more
```